### PR TITLE
Feature restore outfit

### DIFF
--- a/main.js
+++ b/main.js
@@ -306,4 +306,11 @@ function removeSavedOutfit(event){
       bearType = item;
        }
      }
+  if(bearType) {
+        if(bearType.background !== '') {
+          document.getElementById(bearType.background).click();
+          saveBtn.disabled = false;
+        }
+
+}
 }

--- a/main.js
+++ b/main.js
@@ -297,4 +297,13 @@ function removeSavedOutfit(event){
     }
     nameInput.value = outfitTitle;
  }
+    //trigger click events on appropriate buttons
+    var values = Object.values(localStorage);
+    var bearType;
+    for(let i = 0, len = values.length; i < len; i++) {
+    var item = JSON.parse(values[i]);
+    if (item.title === outfitTitle) {
+      bearType = item;
+       }
+     }
 }

--- a/main.js
+++ b/main.js
@@ -278,12 +278,20 @@ function loadSavedOutfits(){
 //remo
 function removeSavedOutfit(event){
   if (event.target.classList.contains('close-icon')){
+
       event.target.parentElement.remove();
       localStorage.removeItem(event.target.parentElement.innerText.trim());
+      console.log('remove saved outfit');
       clearAllBtns();
     }
+     else {
+    populateInput(event);
+  }
 
-  else {
+  }
+
+function populateInput(event) {
+  console.log('populate event');
      //remove all clothes from BEAR
      //remove all highlights from buttons
     clearAllBtns();
@@ -296,8 +304,10 @@ function removeSavedOutfit(event){
     outfitTitle = event.target.firstElementChild.innerHTML;
     }
     nameInput.value = outfitTitle;
+    redressBear(outfitTitle);
  }
-    //trigger click events on appropriate buttons
+//     //trigger click events on appropriate buttons
+  function redressBear(outfitTitle) {
     var values = Object.values(localStorage);
     var bearType;
     for(let i = 0, len = values.length; i < len; i++) {
@@ -311,11 +321,10 @@ function removeSavedOutfit(event){
           document.getElementById(bearType.background).click();
           saveBtn.disabled = false;
         }
-
-}
+    }
   for(let i = 0, len = bearType.garments.length; i < len; i++) {
           document.getElementById(bearType.garments[i]).click();
           saveBtn.disabled = false;
         }
         console.log(bearType.garments);
-      }
+}

--- a/main.js
+++ b/main.js
@@ -30,6 +30,8 @@ saveBtn.addEventListener('click', createCard);
 nameInput.addEventListener('input', disableSaveBtn);
 cardContainer.addEventListener('click', removeSavedOutfit);
 
+
+
 // function saveOutfit (){
 //   createCard();
 // }
@@ -272,10 +274,27 @@ function loadSavedOutfits(){
     closet.push(new Outfit(outfitObj.id, outfitObj.title, outfitObj.garments, outfitObj.background));
   })
 }
-
-function removeSavedOutfit(){
+//maybe rename to handleCardClick
+//remo
+function removeSavedOutfit(event){
   if (event.target.classList.contains('close-icon')){
       event.target.parentElement.remove();
-      localStorage.removeItem(event.target.parentElement.innerText.trim())
-  }
+      localStorage.removeItem(event.target.parentElement.innerText.trim());
+      clearAllBtns();
+    }
+
+  else {
+     //remove all clothes from BEAR
+     //remove all highlights from buttons
+    clearAllBtns();
+     //fill in input field with card title
+    var outfitTitle;
+    if(event.target.classList.contains('outfit-name')) {
+    outfitTitle = event.target.innerHTML;
+    }
+    else {
+    outfitTitle = event.target.firstElementChild.innerHTML;
+    }
+    nameInput.value = outfitTitle;
+ }
 }

--- a/main.js
+++ b/main.js
@@ -313,4 +313,9 @@ function removeSavedOutfit(event){
         }
 
 }
-}
+  for(let i = 0, len = bearType.garments.length; i < len; i++) {
+          document.getElementById(bearType.garments[i]).click();
+          saveBtn.disabled = false;
+        }
+        console.log(bearType.garments);
+      }


### PR DESCRIPTION
### Type of change made:
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling- no new features

### Detailed Description
when a saved outfit card is clicked the corresponding outfit is reloaded on the bear. So is the background. the corresponding buttons are highlighted and the input field is populated with the name of the title card. 

### Why is this change required? What problem does it solve?


### Were there any challenges that arose while implementing this feature? If so, how were the addressed?

### Files modified:
- [ ] index.html
- [ ] styles.css
- [x] main.js
- [ ] Other files:
