### PR TITLE
Fix bug so input does not populate if you click outside of card

### DIFF
--- a/main.js
+++ b/main.js
@@ -293,6 +293,10 @@ function removeSavedOutfit(event){
       console.log('remove saved outfit');
       clearAllBtns();
     }
+
+  else if (event.target.classList.contains('card-container')) {
+      return false;
+  }
      else {
     populateInput(event);
   }


### PR DESCRIPTION
### Type of change made:
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling- no new features

### Detailed Description
When you click outside of the card in card container it no longer populates the input field with HTML
### Why is this change required? What problem does it solve?
needed to just get title of card to populate input field, nothing else
### Were there any challenges that arose while implementing this feature? If so, how were the addressed?

### Files modified:
- [ ] index.html
- [ ] styles.css
- [x] main.js
- [ ] Other files:
